### PR TITLE
Multi-target

### DIFF
--- a/RectpackSharp/PackingHints.cs
+++ b/RectpackSharp/PackingHints.cs
@@ -90,7 +90,11 @@ namespace RectpackSharp
         /// <remarks>
         /// The <see cref="PackingRectangle.SortKey"/> values will be modified.
         /// </remarks>
+#if NET5_0_OR_GREATER
+        public static void SortByPackingHint(Span<PackingRectangle> rectangles, PackingHints packingHint)
+#elif NETSTANDARD2_0
         public static void SortByPackingHint(PackingRectangle[] rectangles, PackingHints packingHint)
+#endif
         {
             // We first get the appropiate delegate for getting a rectangle's sort key.
             GetSortKeyDelegate getKeyDelegate;
@@ -123,7 +127,11 @@ namespace RectpackSharp
                 rectangles[i].SortKey = getKeyDelegate(rectangles[i]);
 
             // We sort the array, using the default rectangle comparison (which compares sort keys).
+#if NET5_0_OR_GREATER
+            rectangles.Sort();
+#elif NETSTANDARD2_0
             Array.Sort(rectangles);
+#endif
         }
     }
 }

--- a/RectpackSharp/RectanglePacker.cs
+++ b/RectpackSharp/RectanglePacker.cs
@@ -26,9 +26,15 @@ namespace RectpackSharp
         /// <remarks>
         /// The <see cref="PackingRectangle.Id"/> values are never touched. Use this to identify your rectangles.
         /// </remarks>
+#if NET5_0_OR_GREATER
+        public static void Pack(Span<PackingRectangle> rectangles, out PackingRectangle bounds,
+            PackingHints packingHint = PackingHints.FindBest, double acceptableDensity = 1, uint stepSize = 1,
+            uint? maxBoundsWidth = null, uint? maxBoundsHeight = null)
+#elif NETSTANDARD2_0
         public static void Pack(PackingRectangle[] rectangles, out PackingRectangle bounds,
             PackingHints packingHint = PackingHints.FindBest, double acceptableDensity = 1, uint stepSize = 1,
             uint? maxBoundsWidth = null, uint? maxBoundsHeight = null)
+#endif
         {
             if (rectangles == null)
                 throw new ArgumentNullException(nameof(rectangles));
@@ -78,15 +84,26 @@ namespace RectpackSharp
             bool hasSolution = false;
 
             // In one array we'll store the current best solution, and we'll also need two temporary arrays.
+#if NET5_0_OR_GREATER
+            Span<PackingRectangle> currentBest = rectangles;
+            Span<PackingRectangle> tmpBest = new PackingRectangle[rectangles.Length];
+            Span<PackingRectangle> tmpArray = new PackingRectangle[rectangles.Length];
+#elif NETSTANDARD2_0
             PackingRectangle[] currentBest = rectangles;
             PackingRectangle[] tmpBest = new PackingRectangle[rectangles.Length];
             PackingRectangle[] tmpArray = new PackingRectangle[rectangles.Length];
+#endif
+       
 
             // For each of the specified hints, we try to pack and see if we can find a better solution.
             for (int i = 0; i < hints.Length && (!hasSolution || currentBestArea > acceptableBoundsArea); i++)
             {
                 // We copy the rectangles onto the tmpBest array, then sort them by what the packing hint says.
+#if NET5_0_OR_GREATER
+                currentBest.CopyTo(tmpBest);
+#elif NETSTANDARD2_0
                 currentBest.CopyTo(tmpBest, 0);
+#endif
                 PackingHintExtensions.SortByPackingHint(tmpBest, hints[i]);
 
                 // We try to find the best bin for the rectangles in tmpBest. We give the function as
@@ -104,7 +121,11 @@ namespace RectpackSharp
                     binHeight = bounds.Height;
 
                     // We swap tmpBest and currentBest
+#if NET5_0_OR_GREATER
+                    Span<PackingRectangle> swaptmp = tmpBest;
+#elif NETSTANDARD2_0
                     PackingRectangle[] swaptmp = tmpBest;
+#endif
                     tmpBest = currentBest;
                     currentBest = swaptmp;
                     hasSolution = true;
@@ -116,7 +137,11 @@ namespace RectpackSharp
 
             // The solution should be in the "rectangles" array passed as parameter.
             if (currentBest != rectangles)
+#if NET5_0_OR_GREATER
+                currentBest.CopyTo(rectangles);
+#elif NETSTANDARD2_0
                 currentBest.CopyTo(rectangles, 0);
+#endif
 
             // We return the list so it can be used in subsequent pack operations.
             ReturnList(emptySpaces);
@@ -135,8 +160,13 @@ namespace RectpackSharp
         /// <param name="acceptableArea">Stops searching once a bin with this area or less is found.</param>
         /// <param name="bounds">The bounds of the resulting bin (0, 0, width, height).</param>
         /// <returns>Whether a solution was found.</returns>
+#if NET5_0_OR_GREATER
+        private static bool TryFindBestBin(List<PackingRectangle> emptySpaces, ref Span<PackingRectangle> rectangles,
+            ref Span<PackingRectangle> tmpArray, uint binWidth, uint binHeight, uint stepSize, uint acceptableArea, out PackingRectangle bounds)
+#elif NETSTANDARD2_0
         private static bool TryFindBestBin(List<PackingRectangle> emptySpaces, ref PackingRectangle[] rectangles,
             ref PackingRectangle[] tmpArray, uint binWidth, uint binHeight, uint stepSize, uint acceptableArea, out PackingRectangle bounds)
+#endif
         {
             // We set boundsWidth and boundsHeight to these initial
             // values so they're not good enough for acceptableArea.
@@ -151,7 +181,12 @@ namespace RectpackSharp
             {
                 bounds.Width = boundsWidth;
                 bounds.Height = boundsHeight;
+                
+#if NET5_0_OR_GREATER
+                Span<PackingRectangle> swaptmp = rectangles;
+#elif NETSTANDARD2_0
                 PackingRectangle[] swaptmp = rectangles;
+#endif
                 rectangles = tmpArray;
                 tmpArray = swaptmp;
 

--- a/RectpackSharp/RectpackSharp.csproj
+++ b/RectpackSharp/RectpackSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>ThomasMiz</Authors>
     <Company>ThomasMiz</Company>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allows for newer .NET versions to use `Span<PackingRectangle>` instead of `PackingRectangle[]`. 

Therefore allowing:
- Better compability with newer versions
- Faster and better optimisation by the JIT
- Possibility to use memory that comes from i.e. `stackalloc` or `NativeMemory.Alloc` if it has been wrapped with a `Span` (which is important to me and which is why i opened this PR)

.NET5 has been choosen as target since its the oldest framework that has `Span.Sort`, and therefore providing maximum compability.